### PR TITLE
bug fixes

### DIFF
--- a/bin/atx
+++ b/bin/atx
@@ -29,5 +29,12 @@ fi
 selected=$( (aws-okta list | awk '{print $1}'; echo "${current}")  \
             | fzf -0 -1 --tac -q "${1:-""}" --prompt "$current> " --preview "$prefix/helpers/atx-preview.sh {}")
 if [ ! -z "$selected" ]; then
-  eval $(aws-okta exec "${selected}" -- env | grep -i aws)
+  output=$(aws-okta exec "${selected}" -- env | grep AWS)
+  env_vars=($output)
+  for (( i=0; i<${#env_vars[@]}; i++ ))
+  do 
+    name=$(echo ${env_vars[$i]} | awk -F= '{print $1}')
+    val=$(echo ${env_vars[$i]} | awk -F= '{print $2}')
+    export $name=$val
+  done
 fi


### PR DESCRIPTION
`aws-okta exec` stopped creating a new session when ran. This update exports AWS environment variables produced by the `aws-okta exec` command into your current bash session. 

**this has not been tested with zsh** 